### PR TITLE
Add FAQ page with accordion

### DIFF
--- a/WebApp/Controllers/FAQController.cs
+++ b/WebApp/Controllers/FAQController.cs
@@ -1,0 +1,21 @@
+using Microsoft.AspNetCore.Mvc;
+using WebApp.Models;
+
+namespace WebApp.Controllers;
+
+public class FAQController : Controller
+{
+    [HttpGet]
+    public IActionResult Index()
+    {
+        var faqs = new List<FaqItem>
+        {
+            new() { Question = "What is this site?", Answer = "A simple ASP.NET Core MVC application." },
+            new() { Question = "How do I contact support?", Answer = "Use the Contact page." },
+            new() { Question = "Can I leave feedback?", Answer = "Yes, visit the Feedback page." }
+        };
+
+        return View(faqs);
+    }
+}
+

--- a/WebApp/Models/FaqItem.cs
+++ b/WebApp/Models/FaqItem.cs
@@ -1,0 +1,8 @@
+namespace WebApp.Models;
+
+public class FaqItem
+{
+    public string Question { get; set; } = string.Empty;
+    public string Answer { get; set; } = string.Empty;
+}
+

--- a/WebApp/Program.cs
+++ b/WebApp/Program.cs
@@ -9,21 +9,17 @@ var app = builder.Build();
 if (!app.Environment.IsDevelopment())
 {
     app.UseExceptionHandler("/Home/Error");
-    // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
     app.UseHsts();
 }
 
 app.UseHttpsRedirection();
+app.UseStaticFiles();
 app.UseRouting();
 
 app.UseAuthorization();
 
-app.MapStaticAssets();
-
 app.MapControllerRoute(
     name: "default",
-    pattern: "{controller=Home}/{action=Index}/{id?}")
-    .WithStaticAssets();
-
+    pattern: "{controller=Home}/{action=Index}/{id?}");
 
 app.Run();

--- a/WebApp/Views/FAQ/Index.cshtml
+++ b/WebApp/Views/FAQ/Index.cshtml
@@ -1,0 +1,28 @@
+@model List<WebApp.Models.FaqItem>
+@{
+    ViewData["Title"] = "FAQ";
+}
+
+<h1>Frequently Asked Questions</h1>
+
+<div class="accordion" id="faqAccordion">
+@for (var i = 0; i < Model.Count; i++)
+{
+    var item = Model[i];
+    var headingId = $"heading{i}";
+    var collapseId = $"collapse{i}";
+    <div class="accordion-item">
+        <h2 class="accordion-header" id="@headingId">
+            <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#@collapseId" aria-expanded="false" aria-controls="@collapseId">
+                @item.Question
+            </button>
+        </h2>
+        <div id="@collapseId" class="accordion-collapse collapse" aria-labelledby="@headingId" data-bs-parent="#faqAccordion">
+            <div class="accordion-body">
+                @item.Answer
+            </div>
+        </div>
+    </div>
+}
+</div>
+

--- a/WebApp/Views/Shared/_Layout.cshtml
+++ b/WebApp/Views/Shared/_Layout.cshtml
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="utf-8" />
@@ -31,6 +31,9 @@
                         </li>
                         <li class="nav-item">
                             <a class="nav-link text-dark" asp-area="" asp-controller="Feedback" asp-action="Index">Feedback</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link text-dark" asp-area="" asp-controller="FAQ" asp-action="Index">FAQ</a>
                         </li>
                     </ul>
                 </div>


### PR DESCRIPTION
## Summary
- add FaqItem model and FAQ controller returning sample questions
- show FAQ entries using a Bootstrap accordion
- link FAQ page from site navigation and ensure static files served

## Testing
- `dotnet build WebApp/WebApp.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68ba94736f1c8333babbb53227346f24